### PR TITLE
Added support for negative TIME2 values (Version 2.0)

### DIFF
--- a/src/MySqlCdc/Parsers/ColumnParser.cs
+++ b/src/MySqlCdc/Parsers/ColumnParser.cs
@@ -211,12 +211,10 @@ namespace MySqlCdc.Columns
 
         public TimeSpan ParseTime2(ref PacketReader reader, int metadata)
         {
-            // On disk we convert from signed representation to unsigned
-            // representation using TIMEF_OFS, so all values become binary comparable.
 
-            //#define TIMEF_OFS 0x800000000000LL
-            //#define TIMEF_INT_OFS 0x800000LL
-
+            // see MySQL server, my_time.cc
+            // #define TIMEF_INT_OFS 0x800000LL
+            // https://github.com/mysql/mysql-server/blob/ea7d2e2d16ac03afdd9cb72a972a95981107bf51/mysys/my_time.cc#L1734
             const long TIMEF_INT_OFS = 0x800000;
             
             long value = reader.ReadIntBigEndian(3);

--- a/src/MySqlCdc/Parsers/ColumnParser.cs
+++ b/src/MySqlCdc/Parsers/ColumnParser.cs
@@ -211,25 +211,45 @@ namespace MySqlCdc.Columns
 
         public TimeSpan ParseTime2(ref PacketReader reader, int metadata)
         {
-            int value = reader.ReadIntBigEndian(3);
-            int millisecond = ParseFractionalPart(ref reader, metadata) / 1000;
+            // On disk we convert from signed representation to unsigned
+            // representation using TIMEF_OFS, so all values become binary comparable.
 
-            bool negative = ((value >> 23) & 1) == 0;
+            //#define TIMEF_OFS 0x800000000000LL
+            //#define TIMEF_INT_OFS 0x800000LL
+
+            const long TIMEF_INT_OFS = 0x800000;
+            
+            long value = reader.ReadIntBigEndian(3);
+            value -= TIMEF_INT_OFS;
+            int frac = ParseFractionalPart(ref reader, metadata);
+
+            bool negative = value < 0;
             if (negative)
             {
+                if (frac != 0)
+                {
+                    value++;
+                    frac = 0x100 - frac;
+                }
+
+                value *= (-1);
                 // It looks like other similar clients don't parse TIME2 values properly
                 // In negative time values both TIME and FSP are stored in reverse order
                 // See https://github.com/mysql/mysql-server/blob/ea7d2e2d16ac03afdd9cb72a972a95981107bf51/sql/log_event.cc#L2022
                 // See https://github.com/mysql/mysql-server/blob/ea7d2e2d16ac03afdd9cb72a972a95981107bf51/mysys/my_time.cc#L1784
-                throw new NotSupportedException("Parsing negative TIME values is not supported in this version");
+                //throw new NotSupportedException("Parsing negative TIME values is not supported in this version");
             }
 
+            int millisecond = frac / 1000;
+            
             // 1 bit sign. 1 bit unused. 10 bits hour. 6 bits minute. 6 bits second.
-            int hour = (value >> 12) % (1 << 10);
-            int minute = (value >> 6) % (1 << 6);
-            int second = value % (1 << 6);
+            // -01:05:10.20
+            long hour = (value >> 12) % (1 << 10);
+            long minute = (value >> 6) % (1 << 6);
+            long second = value % (1 << 6);
 
-            return new TimeSpan(0, hour, minute, second, millisecond);
+            TimeSpan ts = new TimeSpan(0, (int)hour, (int)minute, (int)second, millisecond);
+            return negative ? ts.Negate() : ts;
         }
 
         public DateTimeOffset ParseTimeStamp2(ref PacketReader reader, int metadata)

--- a/tests/MySqlCdc.Tests/Parsers/ColumnParserTests.cs
+++ b/tests/MySqlCdc.Tests/Parsers/ColumnParserTests.cs
@@ -282,7 +282,47 @@ namespace MySqlCdc.Tests.Providers
             Assert.Equal(4, reader.Consumed);
         }
 
-        [Fact(Skip = "See ParseTime2 method implementation")]
+        [Fact]
+        public void Test_Time2_Positive_Len4()
+        {
+            // time(2), column = '15:22:33.1234'
+            byte[] payload = new byte[] { 128, 245, 161, 4, 210 };
+            var reader = new PacketReader(payload);
+            int metadata = 4;
+
+            var expected = new TimeSpan(0, 15, 22, 33);
+            expected = expected.Add(TimeSpan.FromMilliseconds(123.4));
+            Assert.Equal(expected, _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(5, reader.Consumed);
+        }
+
+        [Fact]
+        public void Test_Time2_Positive_Len6()
+        {
+            // time(2), column = '15:22:33.123456'
+            byte[] payload = new byte[] { 128, 245, 161, 1, 226, 64};
+            var reader = new PacketReader(payload);
+            int metadata = 6;
+
+            var expected = new TimeSpan(0, 15, 22, 33);
+            expected = expected.Add(TimeSpan.FromMilliseconds(123.456));
+            Assert.Equal(expected, _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(6, reader.Consumed);
+        }
+
+        [Fact]
+        public void Test_Time2_Negative_without_fraction()
+        {
+            // time(2), column = '-11:05:10'
+            byte[] payload = new byte[] { 127, 78, 182 };
+            var reader = new PacketReader(payload);
+            int metadata = 0;
+
+            Assert.Equal(new TimeSpan(0, 11, 05, 10, 0).Negate(), _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(3, reader.Consumed);
+        }
+
+        [Fact]
         public void Test_Time2_Negative()
         {
             // time(2), column = '-15:22:33.67'
@@ -290,8 +330,64 @@ namespace MySqlCdc.Tests.Providers
             var reader = new PacketReader(payload);
             int metadata = 2;
 
-            Assert.Equal(new TimeSpan(0, -15, 22, 33, 67), _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(new TimeSpan(0, 15, 22, 33, 670).Negate(), _columnParser.ParseTime2(ref reader, metadata));
             Assert.Equal(4, reader.Consumed);
+        }
+
+        [Fact]
+        public void Test_Time2_Negative_Len_3()
+        {
+            // time(2), column = '-15:22:33.123'
+            byte[] payload = new byte[] { 127, 10, 94, 251, 50 };
+            var reader = new PacketReader(payload);
+            int metadata = 4;
+
+            var expected = new TimeSpan(0, 15, 22, 33);
+            expected = expected.Add(TimeSpan.FromMilliseconds(123));
+            Assert.Equal(expected.Negate(), _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(5, reader.Consumed);
+        }
+
+        [Fact]
+        public void Test_Time2_Negative_Len_4()
+        {
+            // time(2), column = '-15:22:33.1234'
+            byte[] payload = new byte[] { 127, 10, 94, 251, 46 };
+            var reader = new PacketReader(payload);
+            int metadata = 4;
+
+            var expected = new TimeSpan(0, 15, 22, 33);
+            expected = expected.Add(TimeSpan.FromMilliseconds(123.4));
+            Assert.Equal(expected.Negate(), _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(5, reader.Consumed);
+        }
+
+        [Fact]
+        public void Test_Time2_Negative_Len_5()
+        {
+            // time(2), column = '-15:22:33.12345'
+            byte[] payload = new byte[] { 127, 10, 94, 254, 29, 198 };
+            var reader = new PacketReader(payload);
+            int metadata = 6;
+
+            var expected = new TimeSpan(0, 15, 22, 33);
+            expected = expected.Add(TimeSpan.FromMilliseconds(123.45));
+            Assert.Equal(expected.Negate(), _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(6, reader.Consumed);
+        }
+
+        [Fact]
+        public void Test_Time2_Negative_Len_6()
+        {
+            // time(2), column = '-15:22:33.123456'
+            byte[] payload = new byte[] { 127, 10, 94, 254, 29, 192 };
+            var reader = new PacketReader(payload);
+            int metadata = 6;
+
+            var expected = new TimeSpan(0, 15, 22, 33);
+            expected = expected.Add(TimeSpan.FromMilliseconds(123.456));
+            Assert.Equal(expected.Negate(), _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(6, reader.Consumed);
         }
 
         [Fact]
@@ -344,7 +440,7 @@ namespace MySqlCdc.Tests.Providers
             Assert.Equal(3, reader.Consumed);
         }
 
-        [Fact(Skip = "See ParseTime method implementation")]
+        [Fact]
         public void Test_Time_Negative()
         {
             // time, column = '-14:12:13'

--- a/tests/MySqlCdc.Tests/Parsers/ColumnParserTests.cs
+++ b/tests/MySqlCdc.Tests/Parsers/ColumnParserTests.cs
@@ -297,6 +297,20 @@ namespace MySqlCdc.Tests.Providers
         }
 
         [Fact]
+        public void Test_Time2_Positive_Len4_with_frac_zero()
+        {
+            // time(2), column = '15:22:33.0000'
+            byte[] payload = new byte[] { 128, 245, 161, 0, 0 };
+            var reader = new PacketReader(payload);
+            int metadata = 4;
+
+            var expected = new TimeSpan(0, 15, 22, 33);
+            expected = expected.Add(TimeSpan.FromMilliseconds(000.0));
+            Assert.Equal(expected, _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(5, reader.Consumed);
+        }
+
+        [Fact]
         public void Test_Time2_Positive_Len6()
         {
             // time(2), column = '15:22:33.123456'
@@ -358,6 +372,20 @@ namespace MySqlCdc.Tests.Providers
 
             var expected = new TimeSpan(0, 15, 22, 33);
             expected = expected.Add(TimeSpan.FromMilliseconds(123.4));
+            Assert.Equal(expected.Negate(), _columnParser.ParseTime2(ref reader, metadata));
+            Assert.Equal(5, reader.Consumed);
+        }
+
+        [Fact]
+        public void Test_Time2_Negative_Len_4_with_frac_zero()
+        {
+            // time(2), column = '-15:22:33.0000'
+            byte[] payload = new byte[] { 127, 10, 95, 0, 0};
+            var reader = new PacketReader(payload);
+            int metadata = 4;
+
+            var expected = new TimeSpan(0, 15, 22, 33);
+            expected = expected.Add(TimeSpan.FromMilliseconds(000.0));
             Assert.Equal(expected.Negate(), _columnParser.ParseTime2(ref reader, metadata));
             Assert.Equal(5, reader.Consumed);
         }


### PR DESCRIPTION
Fixes #34

Instead of throwing
System.NotSupportedException: Parsing negative TIME values is not supported in this version
we parse negative Time2 values from MySQL correctly

Also adding some unit test to verify behavior

This is the PR for 2.0 Version of library as its the last one for .NET Framework
Should be possible to cherry pick the commits to fix this also is the latest version 